### PR TITLE
Pass the pdf viewer command as an optional argument to dump_osx.

### DIFF
--- a/dot.ml
+++ b/dot.ml
@@ -302,7 +302,7 @@ let dump_to_out_channel ?context outc o =
 let dump_to_file ?context filename o =
   with_file_out_channel filename (fun outc -> dump_to_out_channel ?context outc o)
 
-let dump_osx ?context ?(cmd="dot") ?(format="pdf") ?(viewer="open") o =
+let dump_and_open ?context ?(cmd="dot") ~format ~viewer o =
   let exec cmd =
     if Sys.command cmd <> 0 then (
       Printf.eprintf "OCaml Inspect: Could not execute command: %s" cmd;
@@ -319,6 +319,9 @@ let dump_osx ?context ?(cmd="dot") ?(format="pdf") ?(viewer="open") o =
     let outcmd = sprintf "%S %S" viewer outfile in
       if exec dotcmd && exec outcmd then
 	()
+
+let dump_osx ?context ?(cmd="dot") o =
+  dump_and_open ?context ~cmd ~format:"pdf" ~viewer:"open" o
 
 (*----------------------------------------------------------------------------*)
 

--- a/dot.mli
+++ b/dot.mli
@@ -33,16 +33,18 @@ val dump_to_file : ?context:context -> string -> 'a -> unit
 val dump_with_formatter : ?context:context -> Format.formatter -> 'a -> unit
   (** Dump using the [Format] module for pretty printing. *)
 
-val dump_osx : ?context:context -> ?cmd:string -> ?format:string -> ?viewer:string -> 'a -> unit
-  (** [dump_osx ?context ?cmd ?format ?viewer o] dumps the value [o] to a
+val dump_and_open : ?context:context -> ?cmd:string -> format:string -> viewer:string -> 'a -> unit
+  (** [dump_and_open ?context ?cmd ~format ~viewer o] dumps the value [o] to a
       temporary file, runs the Graphviz program given by [cmd] on it
       to generate output as specified by [format], and then opens
-      the generated output with the [viewer] command. The default output
-      format is "pdf".  The default viewer is "open".
+      the generated output with the [viewer] command.
 
       E.g. [Inspect.Dot.dump_osx ~cmd:"neato" (Inspect.test_data ())]
 
       This function will block while the graph is being generated. *)
+
+val dump_osx : ?context:context -> ?cmd:string -> 'a -> unit
+  (** Call {!val:dump_and_open} with [format] "pdf" and [viewer] "open". *)
 
 val test_data : unit -> Obj.t
   (** Generate test data to inspect *)


### PR DESCRIPTION
Overriding the viewer command is all that's needed to make dump_osx (which could perhaps be renamed now) work under Linux.
